### PR TITLE
Add forgot password module

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Users can report concerts, save their favorite bands and cities, and receive upd
 - 🧠 **AI-assisted scraping** of events from multiple sources (starting with [Concertful](https://concertful.com))
 - 📅 **Event database** powered by Supabase
 - 🧾 **User authentication** with email/password and email confirmation
+- 🛠️ **Forgot password module** to reset passwords via email
 - 💌 **Transactional emails** via Resend (signup confirmation, password reset, account deletion)
 - 🛠️ **Admin interface** to moderate events
 - 🌈 **Custom frontend** built with Vite + React + Tailwind

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import SearchInput from './components/SearchInput';
 import AdminPanel from './components/AdminPanel';
 import UserPanel from './components/UserPanel';
 import LoginPage from './components/LoginPage';
+import ResetPasswordPage from './components/ResetPasswordPage';
 import ProtectedRoute from './components/ProtectedRoute';
 import GoodbyePage from './components/GoodbyePage';
 import Footer from './components/Footer';
@@ -443,15 +444,16 @@ function App() {
         {/* Public Routes */}
         <Route path="/" element={<MainPage />} />
         <Route path="/goodbye" element={<GoodbyePage />} />
-        <Route 
-          path="/login" 
+        <Route
+          path="/login"
           element={
-            <LoginPage 
+            <LoginPage
               isAuthenticated={isAuthenticated}
               onAuthenticated={handleAuthenticated}
             />
-          } 
+          }
         />
+        <Route path="/reset-password" element={<ResetPasswordPage />} />
 
         {/* Protected User Routes */}
         <Route 

--- a/src/components/ForgotPasswordModal.tsx
+++ b/src/components/ForgotPasswordModal.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import { Mail, X } from 'lucide-react';
+import { supabase } from '../lib/supabase';
+
+interface ForgotPasswordModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function ForgotPasswordModal({ isOpen, onClose }: ForgotPasswordModalProps) {
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    setSuccess('');
+
+    try {
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: `${window.location.origin}/reset-password`,
+      });
+      if (error) throw error;
+      setSuccess('Password reset email sent. Check your inbox.');
+    } catch (err: any) {
+      setError(err.message || 'Failed to send reset email');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50 p-4">
+      <div className="bg-coal-800 border-2 border-asphalt-600 p-6 w-full max-w-md">
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center space-x-3">
+            <Mail className="h-6 w-6 text-industrial-green-600" />
+            <h2 className="text-xl font-industrial text-gray-100 tracking-wide uppercase">Password Reset</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="bg-transparent border-2 border-asphalt-500 text-gray-300 p-2 hover:border-burgundy-500 hover:text-white transition-all duration-200"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {success && (
+          <div className="bg-green-900 border-2 border-green-600 text-green-300 p-3 mb-4 font-condensed text-sm uppercase tracking-wide">
+            {success}
+          </div>
+        )}
+        {error && (
+          <div className="bg-burgundy-900 border-2 border-burgundy-600 text-burgundy-300 p-3 mb-4 font-condensed text-sm tracking-wide">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-condensed font-bold text-gray-100 mb-2 uppercase tracking-wide">
+              Email
+            </label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full bg-coal-900 border-2 border-asphalt-600 text-gray-100 px-3 py-2 font-condensed focus:outline-none focus:border-industrial-green-600 text-sm"
+              placeholder="YOUR EMAIL"
+            />
+          </div>
+
+          <div className="flex space-x-4 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 bg-transparent border-2 border-asphalt-500 text-gray-300 px-4 py-2 uppercase tracking-wide font-condensed font-bold hover:border-burgundy-500 hover:text-white transition-all duration-200 text-sm"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="flex-1 bg-industrial-green-800 border-2 border-industrial-green-600 text-white px-4 py-2 uppercase tracking-wide font-condensed font-bold hover:bg-industrial-green-700 transition-all duration-200 disabled:opacity-50 text-sm"
+            >
+              {loading ? 'Sending...' : 'Send Email'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Shield, X, Eye, EyeOff, UserPlus, LogIn, ArrowLeft } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import ForgotPasswordModal from './ForgotPasswordModal';
 
 
 interface LoginPageProps {
@@ -259,30 +260,39 @@ export default function LoginPage({ isAuthenticated, onAuthenticated }: LoginPag
               <label className="block text-sm font-condensed font-bold text-gray-100 mb-2 uppercase tracking-wide">
                 PASSWORD
               </label>
-              <div className="relative">
-                <input
-                  type={showPassword ? 'text' : 'password'}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
+            <div className="relative">
+              <input
+                type={showPassword ? 'text' : 'password'}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
                   required
                   minLength={6}
                   className="w-full bg-coal-900 border-2 border-asphalt-600 text-gray-100 px-3 py-2 pr-10 font-condensed focus:outline-none focus:border-industrial-green-600 text-sm"
-                  placeholder="PASSWORD"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-white transition-colors"
-                >
-                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </button>
-              </div>
-              {mode === 'register' && (
-                <p className="text-xs text-gray-500 mt-1 font-condensed">
-                  Minimum 6 characters
-                </p>
-              )}
+                placeholder="PASSWORD"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-white transition-colors"
+              >
+                {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
             </div>
+            {mode === 'register' && (
+              <p className="text-xs text-gray-500 mt-1 font-condensed">
+                Minimum 6 characters
+              </p>
+            )}
+            {mode === 'login' && (
+              <button
+                type="button"
+                onClick={() => setShowForgotPassword(true)}
+                className="text-industrial-green-600 text-xs mt-2 font-condensed underline hover:text-industrial-green-500"
+              >
+                Forgot your password?
+              </button>
+            )}
+          </div>
 
             {mode === 'register' && (
               <div>
@@ -344,8 +354,10 @@ export default function LoginPage({ isAuthenticated, onAuthenticated }: LoginPag
           </div>
         </div>
       </main>
-
-      
+      <ForgotPasswordModal
+        isOpen={showForgotPassword}
+        onClose={() => setShowForgotPassword(false)}
+      />
     </div>
   );
 }

--- a/src/components/ResetPasswordPage.tsx
+++ b/src/components/ResetPasswordPage.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '../lib/supabase';
+
+export default function ResetPasswordPage() {
+  const navigate = useNavigate();
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+    setLoading(true);
+    setError('');
+    setSuccess('');
+    try {
+      const { error } = await supabase.auth.updateUser({ password });
+      if (error) throw error;
+      setSuccess('Password updated successfully');
+      setTimeout(() => navigate('/login', { replace: true }), 1500);
+    } catch (err: any) {
+      setError(err.message || 'Failed to update password');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-coal-900 p-4">
+      <div className="bg-coal-800 border-2 border-asphalt-600 p-8 w-full max-w-md">
+        <h2 className="text-xl font-industrial text-gray-100 tracking-wide uppercase mb-6">
+          Set New Password
+        </h2>
+
+        {success && (
+          <div className="bg-green-900 border-2 border-green-600 text-green-300 p-3 mb-4 font-condensed text-sm uppercase tracking-wide">
+            {success}
+          </div>
+        )}
+        {error && (
+          <div className="bg-burgundy-900 border-2 border-burgundy-600 text-burgundy-300 p-3 mb-4 font-condensed text-sm tracking-wide">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-condensed font-bold text-gray-100 mb-2 uppercase tracking-wide">
+              New Password
+            </label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={6}
+              className="w-full bg-coal-900 border-2 border-asphalt-600 text-gray-100 px-3 py-2 font-condensed focus:outline-none focus:border-industrial-green-600 text-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-condensed font-bold text-gray-100 mb-2 uppercase tracking-wide">
+              Confirm Password
+            </label>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+              minLength={6}
+              className="w-full bg-coal-900 border-2 border-asphalt-600 text-gray-100 px-3 py-2 font-condensed focus:outline-none focus:border-industrial-green-600 text-sm"
+            />
+          </div>
+          <div className="pt-4">
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full bg-industrial-green-800 border-2 border-industrial-green-600 text-white px-4 py-3 uppercase tracking-wide font-condensed font-bold hover:bg-industrial-green-700 transition-all duration-200 disabled:opacity-50"
+            >
+              {loading ? 'Updating...' : 'Update Password'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/UserAuthModal.tsx
+++ b/src/components/UserAuthModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { User as UserIcon, X, Eye, EyeOff, UserPlus, LogIn } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import ForgotPasswordModal from './ForgotPasswordModal';
 
 interface UserAuthModalProps {
   isOpen: boolean;
@@ -18,6 +19,7 @@ export default function UserAuthModal({ isOpen, onClose, onAuthenticated }: User
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  const [showForgotPassword, setShowForgotPassword] = useState(false);
 
   const validateForm = () => {
     if (!email || !password) {
@@ -204,6 +206,7 @@ export default function UserAuthModal({ isOpen, onClose, onAuthenticated }: User
   if (!isOpen) return null;
 
   return (
+    <>
     <div className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50 p-4">
       <div className="bg-coal-800 border-2 border-asphalt-600 p-6 w-full max-w-md">
         <div className="flex items-center justify-between mb-6">
@@ -306,6 +309,15 @@ export default function UserAuthModal({ isOpen, onClose, onAuthenticated }: User
                 Minimum 6 characters
               </p>
             )}
+            {mode === 'login' && (
+              <button
+                type="button"
+                onClick={() => setShowForgotPassword(true)}
+                className="text-industrial-green-600 text-xs mt-2 font-condensed underline hover:text-industrial-green-500"
+              >
+                Forgot your password?
+              </button>
+            )}
           </div>
 
           {mode === 'register' && (
@@ -383,5 +395,10 @@ export default function UserAuthModal({ isOpen, onClose, onAuthenticated }: User
         </div>
       </div>
     </div>
+    <ForgotPasswordModal
+      isOpen={showForgotPassword}
+      onClose={() => setShowForgotPassword(false)}
+    />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add a modal to request password reset emails
- add a page to set a new password after clicking the email link
- expose the forgot-password flow in login pages and modal
- route `/reset-password` in the app router
- document the new feature in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check` *(fails: unable to download deps)*

------
https://chatgpt.com/codex/tasks/task_e_68750ae3e300832dadd96b74536c752a