### PR TITLE
Filter out past events

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,11 +74,15 @@ function MainPage() {
 
       if (error) throw error;
       
-      // Filter for approved events on the client side as a fallback
-      const approvedEvents = (data || []).filter(event => 
-        (event.status || 'approved') === 'approved'
-      );
-      setEvents(approvedEvents);
+      // Filter for approved events and exclude past events
+      const startOfToday = new Date();
+      startOfToday.setHours(0, 0, 0, 0);
+
+      const upcomingApprovedEvents = (data || []).filter(event => (
+        (event.status || 'approved') === 'approved' &&
+        new Date(event.data_ora) >= startOfToday
+      ));
+      setEvents(upcomingApprovedEvents);
     } catch (error) {
       console.error('Error fetching events:', error);
     } finally {


### PR DESCRIPTION
## Summary
- hide past events on the homepage by filtering in `fetchEvents`

## Testing
- `npm run lint` *(fails: cannot find package)*
- `npm run type-check` *(fails: modules not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f4179a060832d8bc0bc52a431fd6b