### PR TITLE
fix(scraper): drop non-existent 'url' column from eventi_prog upsert

### DIFF
--- a/scripts/scrape-events.mjs
+++ b/scripts/scrape-events.mjs
@@ -194,7 +194,6 @@ function normalize(raw, source) {
       descrizione,
       artisti: artisti.length ? artisti : null,
       link,
-      url: link,
       immagine: null,
       fonte: hostOf(source.url),
       tipo_inserimento: 'scraped',


### PR DESCRIPTION
The first real (non-dry-run) execution of the refresh workflow failed: every upsert was rejected with

```
Could not find the 'url' column of 'eventi_prog' in the schema cache
→ inserted 0, updated 0, errors 55
```

`eventi_prog` exposes `link` but has no `url` column. `normalize()` was writing both `link` and `url: link`, so PostgREST rejected the whole insert/update. This removes the stray `url` field. Auth/secrets are fine — the run reached Supabase and only the schema was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)