### PR TITLE
fix: classifySubgenre matches whole words, not substrings

### DIFF
--- a/scripts/scrape-events.mjs
+++ b/scripts/scrape-events.mjs
@@ -225,8 +225,14 @@ function classifySubgenre(eventName, description, artists) {
     'Avant-Prog': ['avant', 'experimental', 'henry cow', 'art rock'],
     'RIO (Rock in Opposition)': ['rio', 'henry cow', 'art bears', 'opposition'],
   };
+  // Match keywords as whole words/phrases (word boundaries) to avoid false
+  // substring hits — e.g. "german" inside "Germany" or "can" inside "American".
+  const matchesWord = (k) => {
+    const esc = k.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp('(^|[^a-z0-9])' + esc + '([^a-z0-9]|$)').test(text);
+  };
   for (const [subgenre, list] of Object.entries(keywords)) {
-    if (list.some(k => text.includes(k))) return subgenre;
+    if (list.some(matchesWord)) return subgenre;
   }
   return 'Progressive';
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -139,8 +139,15 @@ export function classifySubgenre(eventName: string, description?: string, artist
     'RIO (Rock in Opposition)': ['rio', 'henry cow', 'art bears', 'opposition']
   };
 
+  // Match keywords as whole words/phrases (word boundaries) to avoid false
+  // substring hits — e.g. "german" inside "Germany" or "can" inside "American".
+  const matchesWord = (keyword: string) => {
+    const esc = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp('(^|[^a-z0-9])' + esc + '([^a-z0-9]|$)').test(text);
+  };
+
   for (const [subgenre, keywordList] of Object.entries(keywords)) {
-    if (keywordList.some(keyword => text.includes(keyword))) {
+    if (keywordList.some(matchesWord)) {
       return subgenre;
     }
   }


### PR DESCRIPTION
`classifySubgenre()` matched keywords with `text.includes()`, causing false substring hits:

- **`german`** inside "Germany" tagged every Marillion German tour date as **Krautrock** (should be Neo-Prog). Seen live in the first Firecrawl import.
- Same class of bug for `can` (∈ "American"), `yes` (∈ "Yesterday"), `neo` (∈ "neon"), `iq` (∈ "unique"), `rio` (∈ "trio").

The function is shared by the **scraper** and the **live app** (AddEventForm), so both were affected — it's ported verbatim into `scripts/scrape-events.mjs`.

**Fix:** match each keyword at word/phrase boundaries via regex. Worst case now falls through to the safe `'Progressive'` default rather than a wrong subgenre.

**Verification:** 24 assertions run against the actual function text extracted from both files — all pass (real krautrock like Kraftwerk still classifies; false positives now resolve to Progressive). App type-check clean for `supabase.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)