### PR TITLE
feat(scraper): geocode scraped events to city-level coordinates

### DIFF
--- a/scripts/lib/geocode.mjs
+++ b/scripts/lib/geocode.mjs
@@ -1,0 +1,75 @@
+// Shared offline geocoder (Open-Meteo geocoding API, keyless, no cost).
+// Used by:
+//   • scripts/geocode-cities.mjs — builds src/data/cityCoords.json
+//   • scripts/scrape-events.mjs  — attaches city-level lat/lng to scraped events
+// City-level precision; venue-level precision comes from the Google Places picker.
+
+// Country-name → ISO code, to read the country hint out of a `città` string.
+export const CC_ALIAS = {
+  uk: 'GB', 'united kingdom': 'GB', 'great britain': 'GB', england: 'GB', scotland: 'GB', wales: 'GB', 'northern ireland': 'GB',
+  ireland: 'IE',
+  netherlands: 'NL', 'the netherlands': 'NL', holland: 'NL',
+  france: 'FR', germany: 'DE', deutschland: 'DE',
+  italy: 'IT', italia: 'IT',
+  spain: 'ES', 'españa': 'ES', portugal: 'PT',
+  belgium: 'BE', luxembourg: 'LU', switzerland: 'CH', austria: 'AT',
+  poland: 'PL', 'czech republic': 'CZ', czechia: 'CZ', slovakia: 'SK', hungary: 'HU',
+  sweden: 'SE', norway: 'NO', denmark: 'DK', finland: 'FI', iceland: 'IS',
+  estonia: 'EE', latvia: 'LV', lithuania: 'LT',
+  greece: 'GR', turkey: 'TR', 'türkiye': 'TR', turkiye: 'TR',
+  bulgaria: 'BG', romania: 'RO', croatia: 'HR', slovenia: 'SI', serbia: 'RS',
+  usa: 'US', 'u.s.a.': 'US', 'united states': 'US', 'united states of america': 'US',
+  canada: 'CA', mexico: 'MX', brazil: 'BR', argentina: 'AR',
+  japan: 'JP', australia: 'AU', 'new zealand': 'NZ',
+};
+
+// Hand-picked coordinates for names Open-Meteo resolves wrong or not at all
+// (ambiguous exonyms / missing entries). Keyed by the lowercased `città`.
+export const OVERRIDES = {
+  'pompeii, italy': { lat: 40.7497, lng: 14.4869, country: 'Italy', cc: 'IT' },   // Pompei, Campania — Open-Meteo only has Pompeii, Michigan
+  'roma, italy':    { lat: 41.8931, lng: 12.4828, country: 'Italy', cc: 'IT' },   // Rome — "Roma" returns Romania/Texas
+  'genova':         { lat: 44.4056, lng: 8.9463,  country: 'Italy', cc: 'IT' },   // Genoa — "Genova" returns Guatemala
+  'brest':          { lat: 48.3904, lng: -4.4861, country: 'France', cc: 'FR' },  // Brest, Brittany — bare name resolves to Belarus
+  'kempten':        { lat: 47.7267, lng: 10.3139, country: 'Germany', cc: 'DE' }, // Kempten (Allgäu) — bare name resolves to a Zürich suburb
+  'padova':         { lat: 45.4064, lng: 11.8768, country: 'Italy', cc: 'IT' },   // Padua — Open-Meteo's top hit is a wrong small place
+  'bourne, uk':     { lat: 52.7667, lng: -0.3833, country: 'United Kingdom', cc: 'GB' }, // Bourne, Lincolnshire — not Bournemouth
+  'dessel, belgium':{ lat: 51.2385, lng: 5.1145,  country: 'Belgium', cc: 'BE' }, // Dessel, Antwerp — Open-Meteo result order is unstable
+};
+
+// Resolve a `città` string ("City" or "City, Country") to { lat, lng, country, cc }
+// or null when there's no confident match. Never returns a wrong-country result.
+export async function geocode(cityRaw) {
+  if (!cityRaw) return null;
+  const key = cityRaw.toLowerCase();
+  if (OVERRIDES[key]) return OVERRIDES[key];
+
+  const [cityPart, hintPart] = cityRaw.split(',').map((s) => s.trim());
+  const name = cityPart || cityRaw;
+  const rawHint = hintPart ? hintPart.toLowerCase() : null;
+  const hint = rawHint ? (CC_ALIAS[rawHint] || (rawHint.length === 2 ? rawHint.toUpperCase() : null)) : null;
+
+  const url = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(name)}&count=10&language=en&format=json`;
+  const res = await fetch(url);
+  if (!res.ok) return null;
+  const json = await res.json();
+  const results = json.results || [];
+  if (!results.length) return null;
+
+  let pick;
+  if (hint) {
+    // The città names a country → accept ONLY a same-country match; never fall
+    // back to a different country (that's how "Pompeii, Italy" landed in Michigan).
+    pick = results.find((r) => r.country_code === hint);
+    if (!pick) return null;
+  } else {
+    // No country hint → Open-Meteo's top (relevance-ranked) hit; the handful it
+    // gets wrong are pinned in OVERRIDES above.
+    pick = results[0];
+  }
+  return {
+    lat: Number(pick.latitude.toFixed(4)),
+    lng: Number(pick.longitude.toFixed(4)),
+    country: pick.country || null,
+    cc: pick.country_code || null,
+  };
+}

--- a/scripts/scrape-events.mjs
+++ b/scripts/scrape-events.mjs
@@ -23,6 +23,7 @@
 import { writeFile, mkdir } from 'node:fs/promises';
 import { readFileSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { geocode } from './lib/geocode.mjs';
 
 // Load .env for local runs (plain `node` doesn't read it like Vite does).
 // Real environment variables / CI secrets always take precedence.
@@ -251,10 +252,12 @@ async function upsertAll(events) {
       if (selErr) throw selErr;
 
       if (existing) {
-        // Refresh details but never override the moderation status of an existing row.
+        // Refresh details, but keep the existing status and coords (which may be
+        // venue-level from the Places picker) rather than downgrading them.
+        const { lat, lng, ...rest } = ev;
         const { error } = await sb
           .from('eventi_prog')
-          .update({ ...ev, updated_at: new Date().toISOString() })
+          .update({ ...rest, updated_at: new Date().toISOString() })
           .eq('id', existing.id);
         if (error) throw error;
         updated++;
@@ -312,6 +315,19 @@ async function main() {
   if (Object.keys(skipStats).length) {
     console.log('Skipped:', Object.entries(skipStats).map(([k, v]) => `${k}×${v}`).join(', '));
   }
+
+  // Attach city-level coordinates (venue-level precision comes from the Places
+  // picker on manual submissions). Cached per città to avoid duplicate lookups.
+  const geoCache = new Map();
+  let geoOk = 0;
+  for (const ev of events) {
+    if (!geoCache.has(ev.città)) geoCache.set(ev.città, await geocode(ev.città).catch(() => null));
+    const c = geoCache.get(ev.città);
+    ev.lat = c ? c.lat : null;
+    ev.lng = c ? c.lng : null;
+    if (c) geoOk++;
+  }
+  console.log(`Geocoded ${geoOk}/${events.length} events (city-level).`);
 
   if (DRY_RUN) {
     const out = '.firecrawl/last-run.json';

--- a/supabase/migrations/20260711120000_add_event_coordinates.sql
+++ b/supabase/migrations/20260711120000_add_event_coordinates.sql
@@ -1,0 +1,17 @@
+-- Venue/city-level coordinates for events, so the map and "Near you" can place
+-- markers from stored lat/lng instead of re-deriving them from the città string.
+--
+-- Populated by:
+--   • the scraper  (scripts/scrape-events.mjs) — city-level, from the offline geocoder
+--   • the Add Event form — venue-level, captured from the Google Places picker
+--
+-- Existing rows stay NULL until backfilled; the app falls back to resolveCoords(città).
+--
+-- Apply in Supabase → SQL Editor (or `supabase db push`).
+
+alter table public.eventi_prog
+  add column if not exists lat double precision,
+  add column if not exists lng double precision;
+
+comment on column public.eventi_prog.lat is 'Latitude (WGS84). NULL → fall back to city-level coords from città.';
+comment on column public.eventi_prog.lng is 'Longitude (WGS84). NULL → fall back to city-level coords from città.';


### PR DESCRIPTION
Follows the `eventi_prog` lat/lng migration (already applied). Makes the refresh cron store coordinates so the map/​"Near you" can place markers from `event.lat/lng` instead of only re-deriving them from the città string.

## Changes
- **`scripts/lib/geocode.mjs`** (new) — shared offline geocoder (Open-Meteo, keyless). Strict country handling (never returns a wrong-country result — the "Pompeii, Italy → Michigan" bug) + curated overrides for 8 ambiguous names.
- **`scripts/scrape-events.mjs`** — geocodes each event's città to city-level lat/lng (cached per città) and writes them on insert. Re-scrape **updates keep** existing coords (which may be venue-level) rather than downgrading them.
- **migration** `20260711120000_add_event_coordinates.sql` — adds nullable `lat`/`lng` (idempotent; already applied in Supabase).

Venue-level precision for manual submissions comes from the Google Places picker (app side, ships with the redesign).

## Verified
Dry run geocoded 17/22 events correctly, incl. worldwide (Sydney AU, Birmingham UK, Rotterdam NL); unresolvable città stay null → app falls back to city-level `resolveCoords`.

> Note: touches `scrape-events.mjs` alongside the open classifySubgenre PR #20, but in different functions — expect a clean merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)