### PR TITLE
feat(home): map-as-hero + location/period/genre filters + 3 views

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,22 +1,21 @@
 import { useEffect, useMemo, useState, lazy, Suspense } from 'react';
-import { RefreshCw, User as UserIcon, LogOut, Plus, Home as HomeIcon, Search as SearchIcon, Shield } from 'lucide-react';
+import {
+  RefreshCw, User as UserIcon, LogOut, Plus, Home as HomeIcon, Search as SearchIcon,
+  Shield, LayoutGrid, List, AlignJustify, X, MapPin,
+} from 'lucide-react';
 import type { User as SupabaseUser } from '@supabase/auth-js';
 import { supabase } from '../lib/supabase';
 import { Event } from '../types/event';
 import { useUserRole } from '../hooks/useUserRole';
-import { getEventCountry, countryFlag } from '../utils/geo';
+import { getEventCountry, getContinent, CONTINENT_LIST, countryFlag } from '../utils/geo';
 import Logo from './brand/Logo';
-import Waveform from './home/Waveform';
 import SmartSearch from './SmartSearch';
 import NearYou from './home/NearYou';
-import EventCard, { isSoon } from './home/EventCard';
+import EventCard, { CardView } from './home/EventCard';
 
-// Lazy-loaded so MapLibre (~320 kB gzip) stays out of the initial bundle.
 const EventsMap = lazy(() => import('./home/EventsMap'));
 import AddEventForm from './AddEventForm';
 import AuthRequiredModal from './AuthRequiredModal';
-
-type Filter = 'all' | 'week' | string;
 
 export default function HomePage() {
   const [currentUser, setCurrentUser] = useState<SupabaseUser | null>(null);
@@ -24,25 +23,27 @@ export default function HomePage() {
   const { isAdmin } = useUserRole(currentUser);
   const [events, setEvents] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
+
+  // Filters
   const [searchQuery, setSearchQuery] = useState('');
-  const [activeFilter, setActiveFilter] = useState<Filter>('all');
+  const [continent, setContinent] = useState<string | null>(null);
+  const [country, setCountry] = useState<string | null>(null);
+  const [city, setCity] = useState('');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [genre, setGenre] = useState('');
+  const [view, setView] = useState<CardView>('grid');
+
   const [showAddEvent, setShowAddEvent] = useState(false);
   const [showAuthRequired, setShowAuthRequired] = useState(false);
 
   const fetchEvents = async () => {
     try {
-      const { data, error } = await supabase
-        .from('eventi_prog')
-        .select('*')
-        .order('data_ora', { ascending: true });
+      const { data, error } = await supabase.from('eventi_prog').select('*').order('data_ora', { ascending: true });
       if (error) throw error;
-
       const startOfToday = new Date();
       startOfToday.setHours(0, 0, 0, 0);
-      const upcoming = (data || []).filter(
-        (e: Event) => (e.status || 'approved') === 'approved' && new Date(e.data_ora) >= startOfToday
-      );
-      setEvents(upcoming);
+      setEvents((data || []).filter((e: Event) => (e.status || 'approved') === 'approved' && new Date(e.data_ora) >= startOfToday));
     } catch (err) {
       console.error('Error fetching events:', err);
     } finally {
@@ -56,8 +57,6 @@ export default function HomePage() {
     setCurrentUser(session?.user ?? null);
   };
 
-  // The shared <body> is dark (legacy theme). Paint it paper while the light
-  // home is mounted so overscroll doesn't flash dark; restore on unmount.
   useEffect(() => {
     const prev = document.body.style.backgroundColor;
     document.body.style.backgroundColor = '#F5F4F2';
@@ -73,64 +72,54 @@ export default function HomePage() {
       setIsAuthenticated(!!session);
       setCurrentUser(session?.user ?? null);
     });
-    return () => {
-      window.removeEventListener('eventApproved', onApproved);
-      subscription.unsubscribe();
-    };
+    return () => { window.removeEventListener('eventApproved', onApproved); subscription.unsubscribe(); };
   }, []);
 
-  const topSubgenres = useMemo(() => {
-    const counts = new Map<string, number>();
+  // Countries present (optionally scoped to the selected continent), with counts.
+  const countries = useMemo(() => {
+    const m = new Map<string, number>();
     for (const e of events) {
-      const s = e.sottogenere?.trim();
-      if (s) counts.set(s, (counts.get(s) || 0) + 1);
+      const co = getEventCountry(e.città);
+      if (co === 'Other') continue;
+      if (continent && getContinent(co) !== continent) continue;
+      m.set(co, (m.get(co) || 0) + 1);
     }
-    return [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 6).map(([s]) => s);
+    return [...m.entries()].sort((a, b) => b[1] - a[1]);
+  }, [events, continent]);
+
+  const genres = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const e of events) { const g = e.sottogenere?.trim(); if (g) m.set(g, (m.get(g) || 0) + 1); }
+    return [...m.entries()].sort((a, b) => b[1] - a[1]);
   }, [events]);
 
-  const filteredEvents = useMemo(() => {
+  const filtered = useMemo(() => {
     let out = events;
+    if (continent) out = out.filter((e) => getContinent(getEventCountry(e.città)) === continent);
+    if (country) out = out.filter((e) => getEventCountry(e.città) === country);
+    if (city.trim()) { const v = city.toLowerCase().trim(); out = out.filter((e) => e.città.toLowerCase().includes(v)); }
+    if (dateFrom) out = out.filter((e) => e.data_ora.slice(0, 10) >= dateFrom);
+    if (dateTo) out = out.filter((e) => e.data_ora.slice(0, 10) <= dateTo);
+    if (genre) out = out.filter((e) => e.sottogenere === genre);
     const q = searchQuery.toLowerCase().trim();
-    if (q) {
-      if (q.startsWith('venue:')) {
-        const v = q.slice(6).trim();
-        out = out.filter((e) => e.venue.toLowerCase().includes(v));
-      } else if (q.startsWith('city:')) {
-        const v = q.slice(5).trim();
-        out = out.filter((e) => e.città.toLowerCase().includes(v));
-      } else if (q.startsWith('artist:')) {
-        const v = q.slice(7).trim();
-        out = out.filter((e) => e.artisti?.some((a) => a.toLowerCase().includes(v)));
-      } else {
-        out = out.filter((e) =>
-          [e.nome_evento, e.venue, e.città, e.descrizione || '', e.sottogenere, ...(e.artisti || [])]
-            .some((f) => f.toLowerCase().includes(q))
-        );
-      }
-    }
-    if (activeFilter === 'week') out = out.filter((e) => isSoon(e.data_ora));
-    else if (activeFilter !== 'all') out = out.filter((e) => e.sottogenere === activeFilter);
+    if (q) out = out.filter((e) =>
+      [e.nome_evento, e.venue, e.città, e.sottogenere, ...(e.artisti || [])].some((f) => (f || '').toLowerCase().includes(q)));
     return out;
-  }, [events, searchQuery, activeFilter]);
+  }, [events, continent, country, city, dateFrom, dateTo, genre, searchQuery]);
 
-  const countryStats = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const e of events) {
-      const c = getEventCountry(e.città);
-      if (c !== 'Other') counts.set(c, (counts.get(c) || 0) + 1);
-    }
-    const arr = [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
-    const max = arr.length ? arr[0][1] : 1;
-    return { arr, max };
-  }, [events]);
+  const scope = country || continent || 'Worldwide';
+  const hasFilters = !!(continent || country || city || dateFrom || dateTo || genre || searchQuery);
+  const clearAll = () => {
+    setContinent(null); setCountry(null); setCity(''); setDateFrom(''); setDateTo(''); setGenre(''); setSearchQuery('');
+  };
 
   const handleSelectEvent = (e: Event) => { window.location.href = `/event/${e.id}`; };
   const handleRefresh = () => { setLoading(true); fetchEvents(); };
   const handleLogout = async () => { await supabase.auth.signOut(); setIsAuthenticated(false); setCurrentUser(null); };
-  const requestAddEvent = () => {
-    if (!isAuthenticated) setShowAuthRequired(true);
-    else setShowAddEvent(true);
-  };
+  const requestAddEvent = () => { if (!isAuthenticated) setShowAuthRequired(true); else setShowAddEvent(true); };
+  const gotoShows = () => document.getElementById('shows')?.scrollIntoView({ behavior: 'smooth' });
+
+  const gridClass = view === 'grid' ? 'grid' : view === 'list' ? 'list' : 'compact';
 
   return (
     <div className="pd">
@@ -140,20 +129,13 @@ export default function HomePage() {
           <button className="brand" onClick={() => (window.location.href = '/')} aria-label="ProgDealer home">
             <Logo height={28} />
           </button>
-
           <SmartSearch variant="bar" value={searchQuery} onChange={setSearchQuery} events={events} placeholder="Search a band, venue or city…" />
-
           <nav className="topnav">
-            <button className="loc-pill" type="button" title="Location detection arrives with the geo update">
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#E1341E" strokeWidth="2.2">
-                <path d="M12 21s-7-6.3-7-11a7 7 0 0 1 14 0c0 4.7-7 11-7 11Z" />
-                <circle cx="12" cy="10" r="2.4" />
-              </svg>
-              <span><b>Worldwide</b></span>
+            <button className="loc-pill" type="button" onClick={() => document.getElementById('map')?.scrollIntoView({ behavior: 'smooth' })} title="Filter by location on the map">
+              <MapPin size={15} stroke="#E1341E" />
+              <span><b>{scope}</b></span>
             </button>
-            <button className="icon-btn hide-mob" onClick={handleRefresh} title="Refresh events" aria-label="Refresh">
-              <RefreshCw size={16} />
-            </button>
+            <button className="icon-btn hide-mob" onClick={handleRefresh} title="Refresh events" aria-label="Refresh"><RefreshCw size={16} /></button>
             {isAuthenticated ? (
               <>
                 <a className="icon-btn hide-mob" href="/userarea" title="Your area" aria-label="Your area"><UserIcon size={16} /></a>
@@ -162,138 +144,104 @@ export default function HomePage() {
             ) : (
               <a className="btn btn-ghost hide-mob" href="/login">Sign in</a>
             )}
-            <button className="btn btn-accent" onClick={requestAddEvent}>
-              <Plus size={16} /> Add a show
-            </button>
+            <button className="btn btn-accent" onClick={requestAddEvent}><Plus size={16} /> Add a show</button>
           </nav>
         </div>
       </header>
 
-      {/* ---------- Hero ---------- */}
-      <section className="hero">
+      {/* ---------- HERO: the map ---------- */}
+      <section className="hero-map" id="map">
         <div className="wrap">
-          <div className="eyebrow">Live progressive music · worldwide</div>
-          <h1>For the songs too long <em>for the radio.</em></h1>
-          <p className="hero-sub">
-            ProgDealer tracks progressive rock, metal and post-rock shows across the globe —
-            then surfaces the ones happening near you, before they sell out.
-          </p>
-
-          <div className="hero-search">
-            <SmartSearch variant="hero" value={searchQuery} onChange={setSearchQuery} events={events} placeholder="Try &ldquo;Steven Wilson&rdquo;, &ldquo;Alcatraz&rdquo;, or a city…" />
-            <button className="btn btn-solid" onClick={() => document.getElementById('shows')?.scrollIntoView({ behavior: 'smooth' })}>
-              Find shows
-            </button>
-          </div>
-
-          <div className="hero-meta">
-            <span className="live">● {events.length} upcoming</span>
-            <span className="dot" />
-            <span>across <b className="num">{countryStats.arr.length}</b> countries</span>
-            <span className="dot" />
-            <span>Catalog refreshed every <b>15 days</b></span>
-          </div>
-        </div>
-        <Waveform className="hero-wave" />
-      </section>
-
-      {/* ---------- Near you ---------- */}
-      {!loading && events.length > 0 && (
-        <NearYou events={events} onSelect={handleSelectEvent} />
-      )}
-
-      {/* ---------- Map ---------- */}
-      {!loading && events.length > 0 && (
-        <section className="block" id="map">
-          <div className="wrap">
-            <div className="head">
-              <div>
-                <div className="eyebrow">Every show on the map</div>
-                <h2>Shows worldwide</h2>
-                <p>Hit the locate button to center on you. Numbered markers show how many shows are in each city.</p>
-              </div>
+          <div className="hm-head">
+            <div>
+              <div className="eyebrow">Live progressive music · worldwide</div>
+              <h1>Every prog show, on the map.</h1>
             </div>
-            <Suspense fallback={<div className="pd-map" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}><span className="label">Loading map…</span></div>}>
-              <EventsMap events={events} />
-            </Suspense>
+            <div className="hm-meta">
+              <span className="live">● {filtered.length} {filtered.length === 1 ? 'show' : 'shows'}</span>
+              <span className="dot" />
+              <span>in <b>{scope}</b></span>
+            </div>
           </div>
-        </section>
-      )}
+
+          {/* Location filter — drives both the map and the list */}
+          <div className="locbar">
+            <button className={`lc ${!continent && !country ? 'on' : ''}`} onClick={() => { setContinent(null); setCountry(null); }}>🌍 Worldwide</button>
+            {CONTINENT_LIST.map((c) => (
+              <button key={c} className={`lc ${continent === c ? 'on' : ''}`} onClick={() => { setContinent(continent === c ? null : c); setCountry(null); }}>{c}</button>
+            ))}
+          </div>
+          {countries.length > 0 && (
+            <div className="ctybar">
+              {countries.map(([co, n]) => (
+                <button key={co} className={`cty ${country === co ? 'on' : ''}`} onClick={() => setCountry(country === co ? null : co)}>
+                  {countryFlag(co)} {co} <i>{n}</i>
+                </button>
+              ))}
+            </div>
+          )}
+
+          <Suspense fallback={<div className="pd-map pd-map-hero" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}><span className="label">Loading map…</span></div>}>
+            {!loading && events.length > 0
+              ? <EventsMap events={filtered} onCity={(c) => { setCity(c); gotoShows(); }} />
+              : <div className="pd-map pd-map-hero" />}
+          </Suspense>
+        </div>
+      </section>
 
       {/* ---------- Shows ---------- */}
       <section className="block" id="shows">
         <div className="wrap">
-          <div className="head">
-            <div>
-              <div className="eyebrow">{filteredEvents.length} shows</div>
-              <h2>Upcoming shows</h2>
+          <div className="shows-bar">
+            <div className="sb-title"><h2>Upcoming shows</h2><span className="num">{filtered.length}</span></div>
+            <div className="sb-controls">
+              <label className="ctl"><MapPin size={14} /><input type="text" placeholder="City" value={city} onChange={(e) => setCity(e.target.value)} /></label>
+              <label className="ctl"><span>From</span><input type="date" value={dateFrom} onChange={(e) => setDateFrom(e.target.value)} /></label>
+              <label className="ctl"><span>To</span><input type="date" value={dateTo} onChange={(e) => setDateTo(e.target.value)} /></label>
+              <select className="ctl-sel" value={genre} onChange={(e) => setGenre(e.target.value)}>
+                <option value="">All genres</option>
+                {genres.map(([g, n]) => <option key={g} value={g}>{g} ({n})</option>)}
+              </select>
+              {hasFilters && <button className="ctl-clear" onClick={clearAll}><X size={14} /> Clear</button>}
+              <div className="viewtoggle" role="group" aria-label="View">
+                <button className={view === 'grid' ? 'on' : ''} onClick={() => setView('grid')} title="Grid" aria-label="Grid view"><LayoutGrid size={16} /></button>
+                <button className={view === 'list' ? 'on' : ''} onClick={() => setView('list')} title="List" aria-label="List view"><List size={16} /></button>
+                <button className={view === 'compact' ? 'on' : ''} onClick={() => setView('compact')} title="Compact" aria-label="Compact view"><AlignJustify size={16} /></button>
+              </div>
             </div>
-          </div>
-
-          <div className="filters">
-            <button className={`chip ${activeFilter === 'all' ? 'on' : ''}`} onClick={() => setActiveFilter('all')}>All shows</button>
-            <button className={`chip ${activeFilter === 'week' ? 'on' : ''}`} onClick={() => setActiveFilter('week')}>This week</button>
-            {topSubgenres.map((s) => (
-              <button key={s} className={`chip ${activeFilter === s ? 'on' : ''}`} onClick={() => setActiveFilter(s)}>{s}</button>
-            ))}
           </div>
 
           {loading ? (
             <div className="skgrid">{Array.from({ length: 8 }).map((_, i) => <div key={i} className="sk" />)}</div>
-          ) : filteredEvents.length === 0 ? (
+          ) : filtered.length === 0 ? (
             <div className="empty">
-              <h3>No shows match your search</h3>
-              <p>Try a different band, city or subgenre — or clear the filters.</p>
+              <h3>No shows match your filters</h3>
+              <p>Try a wider location, a different date range or genre — or clear the filters.</p>
+              {hasFilters && <button className="btn btn-ghost" onClick={clearAll} style={{ marginTop: 12 }}>Clear filters</button>}
             </div>
           ) : (
-            <div className="grid">
-              {filteredEvents.map((e) => <EventCard key={e.id} event={e} onSelect={handleSelectEvent} />)}
+            <div className={gridClass}>
+              {filtered.map((e) => <EventCard key={e.id} event={e} onSelect={handleSelectEvent} view={view} />)}
             </div>
           )}
         </div>
       </section>
 
-      {/* ---------- Country browse ---------- */}
-      {countryStats.arr.length > 0 && (
-        <section className="block">
-          <div className="wrap">
-            <div className="head">
-              <div>
-                <div className="eyebrow">One catalog · going worldwide</div>
-                <h2>Browse by country</h2>
-              </div>
-            </div>
-            <div className="regions">
-              {countryStats.arr.map(([country, count]) => (
-                <button key={country} className="region" onClick={() => { setSearchQuery(''); setActiveFilter('all'); }}>
-                  <span className="rn">{countryFlag(country)} {country}</span>
-                  <span className="rc num">{count} {count === 1 ? 'show' : 'shows'}</span>
-                  <span className="bar"><i style={{ width: `${Math.max(8, (count / countryStats.max) * 100)}%` }} /></span>
-                </button>
-              ))}
-            </div>
-            <div className="beta">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#B4260F" strokeWidth="2" style={{ flex: '0 0 auto', marginTop: 1 }}>
-                <path d="M12 21s-7-6.3-7-11a7 7 0 0 1 14 0c0 4.7-7 11-7 11Z" /><circle cx="12" cy="10" r="2.4" />
-              </svg>
-              <span>Location-aware “near you” with distances and an interactive map arrive with the geo update — every venue gets real coordinates.</span>
-            </div>
-          </div>
-        </section>
-      )}
+      {/* ---------- Near you ---------- */}
+      {!loading && events.length > 0 && <NearYou events={events} onSelect={handleSelectEvent} />}
 
       {/* ---------- Footer ---------- */}
       <footer className="foot">
         <div className="wrap foot-top">
           <div className="foot-brand">
             <Logo height={28} />
-            <span className="foot-fresh"><span className="pulse" /> Catalog refreshed 4 days ago · next in 11 days</span>
+            <span className="foot-fresh"><span className="pulse" /> Catalog refreshed automatically every 15 days</span>
           </div>
           <div className="foot-cols">
             <div>
               <span className="label">Discover</span>
-              <button onClick={() => setActiveFilter('week')}>This week</button>
-              <button onClick={() => document.getElementById('shows')?.scrollIntoView({ behavior: 'smooth' })}>All shows</button>
+              <button onClick={gotoShows}>All shows</button>
+              <button onClick={() => document.getElementById('map')?.scrollIntoView({ behavior: 'smooth' })}>Map</button>
             </div>
             <div>
               <span className="label">Contribute</span>
@@ -318,19 +266,13 @@ export default function HomePage() {
       {/* ---------- Mobile bottom nav ---------- */}
       <nav className="bnav">
         <a href="/"><HomeIcon size={19} /><span>Home</span></a>
-        <button onClick={() => document.getElementById('shows')?.scrollIntoView({ behavior: 'smooth' })}><SearchIcon size={19} /><span>Browse</span></button>
+        <button onClick={gotoShows}><SearchIcon size={19} /><span>Browse</span></button>
         <button className="fab" onClick={requestAddEvent} aria-label="Add a show"><Plus size={22} /></button>
         <a href={isAuthenticated ? '/userarea' : '/login'}><UserIcon size={19} /><span>Profile</span></a>
       </nav>
 
       {/* ---------- Modals ---------- */}
-      <AddEventForm
-        isOpen={showAddEvent}
-        onClose={() => setShowAddEvent(false)}
-        onEventAdded={fetchEvents}
-        onAuthRequired={() => setShowAuthRequired(true)}
-        isAuthenticated={isAuthenticated}
-      />
+      <AddEventForm isOpen={showAddEvent} onClose={() => setShowAddEvent(false)} onEventAdded={fetchEvents} onAuthRequired={() => setShowAuthRequired(true)} isAuthenticated={isAuthenticated} />
       <AuthRequiredModal isOpen={showAuthRequired} onClose={() => setShowAuthRequired(false)} />
     </div>
   );

--- a/src/components/home/EventCard.tsx
+++ b/src/components/home/EventCard.tsx
@@ -5,7 +5,7 @@ import { shouldUsePlaceholder } from '../../utils/imageUtils';
 
 export function hueFor(subgenre: string): number {
   let h = 0;
-  const s = subgenre || 'progressive';
+  const s = subgenre || 'progressive rock';
   for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) % 360;
   return h;
 }
@@ -24,22 +24,70 @@ export function isSoon(dateIso: string): boolean {
   return d >= now && d - now <= 7 * 24 * 60 * 60 * 1000;
 }
 
-export default function EventCard({ event, onSelect }: { event: Event; onSelect: (e: Event) => void }) {
+export type CardView = 'grid' | 'list' | 'compact';
+
+const Arrow = () => (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4">
+    <path d="M5 12h14M13 6l6 6-6 6" />
+  </svg>
+);
+
+export default function EventCard({
+  event, onSelect, view = 'grid',
+}: { event: Event; onSelect: (e: Event) => void; view?: CardView }) {
   const country = getEventCountry(event.città);
   const date = new Date(event.data_ora);
   const soon = isSoon(event.data_ora);
   const hasImage = !shouldUsePlaceholder(event.immagine);
+  const genre = event.sottogenere || 'Progressive Rock';
 
+  // ---- Compact: dense one-line rows (list/elenco) ----
+  if (view === 'compact') {
+    return (
+      <button className="evc" onClick={() => onSelect(event)} aria-label={event.nome_evento}>
+        <span className="evc-day">
+          <b>{String(date.getDate()).padStart(2, '0')}</b>
+          <i>{dayFmt.format(date).split(' ')[0]} ’{String(date.getFullYear()).slice(2)}</i>
+        </span>
+        <span className="evc-title">{event.nome_evento}</span>
+        <span className="evc-loc">{countryFlag(country)} {event.città}</span>
+        <span className="evc-genre">{genre}</span>
+        {soon && <span className="evc-soon">This week</span>}
+        <span className="evc-go"><Arrow /></span>
+      </button>
+    );
+  }
+
+  // ---- List: horizontal rows with artwork ----
+  if (view === 'list') {
+    return (
+      <button className="evl" onClick={() => onSelect(event)} aria-label={event.nome_evento}>
+        <div className="evl-vis">
+          {hasImage ? <img src={event.immagine} alt="" loading="lazy" /> : <CardArt hue={hueFor(genre)} seed={seedFor(event.id)} />}
+          {soon && <span className="soon">This week</span>}
+        </div>
+        <div className="evl-main">
+          <div className="ev-date">{dayFmt.format(date)} · {date.getFullYear()}</div>
+          <h3>{event.nome_evento}</h3>
+          <div className="ev-venue"><span className="flag">{countryFlag(country)}</span> {event.venue}, {event.città}</div>
+        </div>
+        <span className="evl-genre">{genre}</span>
+        <span className="go">Details <Arrow /></span>
+      </button>
+    );
+  }
+
+  // ---- Grid (default): full card ----
   return (
     <button className="ev" onClick={() => onSelect(event)} aria-label={event.nome_evento}>
       <div className="ev-vis">
         {hasImage ? (
           <img src={event.immagine} alt="" loading="lazy" />
         ) : (
-          <CardArt hue={hueFor(event.sottogenere)} seed={seedFor(event.id)} />
+          <CardArt hue={hueFor(genre)} seed={seedFor(event.id)} />
         )}
         {soon && <span className="soon">This week</span>}
-        <span className="genre">{event.sottogenere || 'Progressive'}</span>
+        <span className="genre">{genre}</span>
       </div>
       <div className="ev-body">
         <div className="ev-date">
@@ -55,13 +103,7 @@ export default function EventCard({ event, onSelect }: { event: Event; onSelect:
           {event.venue}, {event.città}
         </div>
         <div className="ev-foot">
-          <span className="src">{event.fonte}</span>
-          <span className="go">
-            Details
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4">
-              <path d="M5 12h14M13 6l6 6-6 6" />
-            </svg>
-          </span>
+          <span className="go">Details <Arrow /></span>
         </div>
       </div>
     </button>

--- a/src/components/home/EventsMap.tsx
+++ b/src/components/home/EventsMap.tsx
@@ -22,29 +22,21 @@ const OSM_STYLE: any = {
   layers: [{ id: 'osm', type: 'raster', source: 'osm' }],
 };
 
-export default function EventsMap({ events }: { events: Event[] }) {
+export default function EventsMap({ events, onCity }: { events: Event[]; onCity?: (città: string) => void }) {
   const container = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
+  const markers = useRef<maplibregl.Marker[]>([]);
+  const onCityRef = useRef(onCity);
+  onCityRef.current = onCity;
 
+  // Create the map once.
   useEffect(() => {
     if (!container.current || mapRef.current) return;
-
-    // group events by city (that we have coordinates for)
-    const groups = new Map<string, { lat: number; lng: number; count: number }>();
-    for (const e of events) {
-      const c = coordsForEvent(e);
-      if (!c) continue;
-      const key = e.città;
-      const g = groups.get(key);
-      if (g) g.count++;
-      else groups.set(key, { lat: c.lat, lng: c.lng, count: 1 });
-    }
-
     const map = new maplibregl.Map({
       container: container.current,
       style: OSM_STYLE,
-      center: [10, 48],
-      zoom: 3,
+      center: [8, 30],
+      zoom: 1.3,
       attributionControl: { compact: true },
     });
     mapRef.current = map;
@@ -53,27 +45,47 @@ export default function EventsMap({ events }: { events: Event[] }) {
       new maplibregl.GeolocateControl({ positionOptions: { enableHighAccuracy: true }, showUserLocation: true }),
       'top-right'
     );
+    return () => { map.remove(); mapRef.current = null; };
+  }, []);
+
+  // Rebuild markers + re-fit bounds whenever the (filtered) events change.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    markers.current.forEach((m) => m.remove());
+    markers.current = [];
+
+    const groups = new Map<string, { lat: number; lng: number; count: number }>();
+    for (const e of events) {
+      const c = coordsForEvent(e);
+      if (!c) continue;
+      const g = groups.get(e.città);
+      if (g) g.count++;
+      else groups.set(e.città, { lat: c.lat, lng: c.lng, count: 1 });
+    }
 
     const bounds = new maplibregl.LngLatBounds();
-    for (const [city, g] of groups) {
+    for (const [città, g] of groups) {
       const el = document.createElement('button');
       el.className = 'pd-pin';
       el.type = 'button';
-      el.setAttribute('aria-label', `${city}: ${g.count} shows`);
+      el.setAttribute('aria-label', `${città}: ${g.count} shows`);
       if (g.count > 1) el.textContent = String(g.count);
+      el.addEventListener('click', () => onCityRef.current?.(città));
       const popup = new maplibregl.Popup({ offset: 14, closeButton: false }).setHTML(
-        `<strong>${city}</strong><br>${g.count} ${g.count === 1 ? 'show' : 'shows'}`
+        `<strong>${città}</strong><br>${g.count} ${g.count === 1 ? 'show' : 'shows'}`
       );
-      new maplibregl.Marker({ element: el }).setLngLat([g.lng, g.lat]).setPopup(popup).addTo(map);
+      const marker = new maplibregl.Marker({ element: el }).setLngLat([g.lng, g.lat]).setPopup(popup).addTo(map);
+      markers.current.push(marker);
       bounds.extend([g.lng, g.lat]);
     }
 
-    if (!bounds.isEmpty()) {
-      map.fitBounds(bounds, { padding: 56, maxZoom: 6, duration: 0 });
-    }
-
-    return () => { map.remove(); mapRef.current = null; };
+    const fit = () => {
+      if (bounds.isEmpty()) return;
+      map.fitBounds(bounds, { padding: 64, maxZoom: 9, duration: 600 });
+    };
+    if (map.loaded()) fit(); else map.once('load', fit);
   }, [events]);
 
-  return <div className="pd-map" ref={container} />;
+  return <div className="pd-map pd-map-hero" ref={container} />;
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -152,5 +152,5 @@ export function classifySubgenre(eventName: string, description?: string, artist
     }
   }
 
-  return 'Progressive';
+  return 'Progressive Rock';
 }

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -458,3 +458,72 @@
 .pd .ac-group { font-family: var(--mono); font-size: 0.6rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-3); padding: 9px 12px 4px; }
 .pd .ac-item svg { color: var(--ink-3); margin-right: 8px; vertical-align: -2px; }
 @media (max-width: 719px) { .pd .ac-bar { display: none; } }
+
+/* ==================== Home rebuild: map-hero, location filter, views ==================== */
+
+/* Hero = the map */
+.pd .hero-map { padding: 20px 0 6px; }
+.pd .hm-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 16px; margin-bottom: 14px; flex-wrap: wrap; }
+.pd .hm-head h1 { font-family: var(--serif, Georgia, serif); font-size: clamp(1.7rem, 3.2vw, 2.6rem); line-height: 1.05; letter-spacing: -0.02em; margin: 4px 0 0; }
+.pd .hm-meta { display: flex; align-items: center; gap: 10px; font-size: 0.9rem; color: var(--ink-2); white-space: nowrap; }
+.pd .hm-meta .live { color: var(--accent); font-weight: 600; font-variant-numeric: tabular-nums; }
+.pd .hm-meta b { color: var(--ink); font-weight: 600; }
+
+.pd .pd-map-hero { height: 520px; }
+@media (max-width: 640px) { .pd .pd-map-hero { height: 400px; } }
+
+/* Location filter — continents + countries */
+.pd .locbar { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 10px; }
+.pd .lc { font-family: var(--sans); font-size: 0.86rem; font-weight: 600; padding: 8px 15px; border-radius: 999px; border: 1px solid var(--line); background: var(--card); color: var(--ink-2); cursor: pointer; transition: all 0.14s; }
+.pd .lc:hover { border-color: var(--ink-2); color: var(--ink); }
+.pd .lc.on { background: var(--accent); border-color: var(--accent); color: #fff; }
+.pd .ctybar { display: flex; flex-wrap: wrap; gap: 7px; margin-bottom: 14px; }
+.pd .cty { font-family: var(--sans); font-size: 0.8rem; font-weight: 500; padding: 5px 11px; border-radius: 8px; border: 1px solid var(--line); background: var(--card); color: var(--ink); cursor: pointer; transition: all 0.14s; display: inline-flex; align-items: center; gap: 6px; }
+.pd .cty:hover { border-color: var(--ink-2); }
+.pd .cty.on { background: var(--ink); border-color: var(--ink); color: #fff; }
+.pd .cty i { font-style: normal; font-family: var(--mono); font-size: 0.7rem; color: var(--ink-3); font-variant-numeric: tabular-nums; }
+.pd .cty.on i { color: rgba(255,255,255,0.7); }
+
+/* Shows toolbar */
+.pd .shows-bar { display: flex; align-items: center; justify-content: space-between; gap: 14px; margin-bottom: 18px; flex-wrap: wrap; }
+.pd .sb-title { display: flex; align-items: baseline; gap: 10px; }
+.pd .sb-title h2 { font-family: var(--serif, Georgia, serif); font-size: 1.5rem; margin: 0; }
+.pd .sb-title .num { font-family: var(--mono); font-size: 0.9rem; color: var(--ink-3); }
+.pd .sb-controls { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.pd .ctl, .pd .ctl-sel { display: inline-flex; align-items: center; gap: 6px; height: 36px; padding: 0 10px; border: 1px solid var(--line); border-radius: 9px; background: var(--card); font-family: var(--sans); font-size: 0.82rem; color: var(--ink); cursor: pointer; }
+.pd .ctl span { color: var(--ink-3); font-size: 0.76rem; }
+.pd .ctl input { border: 0; outline: 0; background: transparent; font: inherit; color: var(--ink); width: 92px; }
+.pd .ctl input[type="date"] { width: 130px; cursor: pointer; }
+.pd .ctl-clear { display: inline-flex; align-items: center; gap: 5px; height: 36px; padding: 0 11px; border: 1px solid var(--accent); border-radius: 9px; background: var(--accent-wash); color: var(--accent-deep); font-size: 0.8rem; font-weight: 600; cursor: pointer; }
+.pd .viewtoggle { display: inline-flex; border: 1px solid var(--line); border-radius: 9px; overflow: hidden; background: var(--card); }
+.pd .viewtoggle button { width: 36px; height: 36px; display: grid; place-items: center; border: 0; background: transparent; color: var(--ink-3); cursor: pointer; border-left: 1px solid var(--line); }
+.pd .viewtoggle button:first-child { border-left: 0; }
+.pd .viewtoggle button:hover { color: var(--ink); }
+.pd .viewtoggle button.on { background: var(--ink); color: #fff; }
+
+/* List view */
+.pd .list { display: flex; flex-direction: column; gap: 10px; }
+.pd .evl { display: flex; align-items: center; gap: 14px; width: 100%; text-align: left; background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 10px 14px 10px 10px; cursor: pointer; transition: border-color 0.14s, transform 0.14s; }
+.pd .evl:hover { border-color: var(--ink-2); transform: translateY(-1px); }
+.pd .evl-vis { position: relative; width: 86px; height: 66px; flex: 0 0 auto; border-radius: 9px; overflow: hidden; }
+.pd .evl-vis img, .pd .evl-vis canvas, .pd .evl-vis svg { width: 100%; height: 100%; object-fit: cover; display: block; }
+.pd .evl-vis .soon { position: absolute; top: 5px; left: 5px; font-size: 0.6rem; padding: 2px 6px; }
+.pd .evl-main { flex: 1 1 auto; min-width: 0; }
+.pd .evl-main h3 { font-size: 1rem; margin: 2px 0; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pd .evl-main .ev-venue { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pd .evl-genre { flex: 0 0 auto; font-family: var(--mono); font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--ink-2); background: var(--line-2); padding: 4px 9px; border-radius: 999px; }
+@media (max-width: 640px) { .pd .evl-genre, .pd .evl .go { display: none; } }
+
+/* Compact view */
+.pd .compact { display: flex; flex-direction: column; }
+.pd .evc { display: flex; align-items: center; gap: 14px; width: 100%; text-align: left; padding: 11px 8px; border: 0; border-bottom: 1px solid var(--line-2); background: transparent; cursor: pointer; }
+.pd .evc:hover { background: var(--card); }
+.pd .evc-day { flex: 0 0 auto; width: 62px; display: flex; flex-direction: column; line-height: 1.05; }
+.pd .evc-day b { font-family: var(--mono); font-size: 1.05rem; font-weight: 700; }
+.pd .evc-day i { font-style: normal; font-size: 0.68rem; color: var(--ink-3); text-transform: uppercase; }
+.pd .evc-title { flex: 1 1 auto; min-width: 0; font-weight: 600; font-size: 0.95rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pd .evc-loc { flex: 0 0 auto; width: 210px; color: var(--ink-2); font-size: 0.84rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pd .evc-genre { flex: 0 0 auto; font-family: var(--mono); font-size: 0.64rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--ink-3); }
+.pd .evc-soon { flex: 0 0 auto; font-size: 0.6rem; color: var(--accent); font-weight: 700; text-transform: uppercase; }
+.pd .evc-go { flex: 0 0 auto; color: var(--ink-3); }
+@media (max-width: 720px) { .pd .evc-loc { width: 118px; } .pd .evc-genre, .pd .evc-go { display: none; } }

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -31,17 +31,56 @@ const FLAGS: Record<string, string> = {
   'United Kingdom': '🇬🇧', France: '🇫🇷', Germany: '🇩🇪', Italy: '🇮🇹', Spain: '🇪🇸',
   Netherlands: '🇳🇱', Belgium: '🇧🇪', Switzerland: '🇨🇭', Austria: '🇦🇹', 'Czech Republic': '🇨🇿',
   Poland: '🇵🇱', Sweden: '🇸🇪', Denmark: '🇩🇰', Norway: '🇳🇴', Finland: '🇫🇮', Ireland: '🇮🇪',
-  Portugal: '🇵🇹', 'United States': '🇺🇸', Canada: '🇨🇦', Japan: '🇯🇵', Australia: '🇦🇺',
-  Brazil: '🇧🇷', Mexico: '🇲🇽', Other: '🌍',
+  Portugal: '🇵🇹', Greece: '🇬🇷', Hungary: '🇭🇺', Romania: '🇷🇴', Bulgaria: '🇧🇬', Estonia: '🇪🇪',
+  Slovenia: '🇸🇮', Croatia: '🇭🇷', Serbia: '🇷🇸', Turkey: '🇹🇷', Luxembourg: '🇱🇺', Iceland: '🇮🇸',
+  'United States': '🇺🇸', Canada: '🇨🇦', Mexico: '🇲🇽', Japan: '🇯🇵', Australia: '🇦🇺',
+  'New Zealand': '🇳🇿', Brazil: '🇧🇷', Argentina: '🇦🇷', Chile: '🇨🇱', Other: '🌍',
 };
 
-export function getEventCountry(city: string): string {
-  const c = (city || '').toLowerCase();
+// Country → continent, for the location filter.
+const CONTINENTS: Record<string, string> = {
+  'United Kingdom': 'Europe', France: 'Europe', Germany: 'Europe', Italy: 'Europe', Spain: 'Europe',
+  Netherlands: 'Europe', Belgium: 'Europe', Switzerland: 'Europe', Austria: 'Europe', 'Czech Republic': 'Europe',
+  Poland: 'Europe', Sweden: 'Europe', Denmark: 'Europe', Norway: 'Europe', Finland: 'Europe', Ireland: 'Europe',
+  Portugal: 'Europe', Greece: 'Europe', Hungary: 'Europe', Romania: 'Europe', Bulgaria: 'Europe', Estonia: 'Europe',
+  Slovenia: 'Europe', Croatia: 'Europe', Serbia: 'Europe', Turkey: 'Europe', Luxembourg: 'Europe', Iceland: 'Europe',
+  'United States': 'North America', Canada: 'North America', Mexico: 'North America',
+  Brazil: 'South America', Argentina: 'South America', Chile: 'South America',
+  Japan: 'Asia', Australia: 'Oceania', 'New Zealand': 'Oceania',
+};
+
+// Normalize the country token that may appear after the comma in a `città`.
+const COUNTRY_ALIAS: Record<string, string> = {
+  uk: 'United Kingdom', 'u.k.': 'United Kingdom', england: 'United Kingdom', scotland: 'United Kingdom',
+  wales: 'United Kingdom', 'great britain': 'United Kingdom', 'united kingdom': 'United Kingdom',
+  usa: 'United States', 'u.s.a.': 'United States', us: 'United States', 'united states': 'United States',
+  'united states of america': 'United States', america: 'United States',
+  'the netherlands': 'Netherlands', holland: 'Netherlands', netherlands: 'Netherlands',
+  deutschland: 'Germany', germany: 'Germany', italia: 'Italy', italy: 'Italy',
+  'españa': 'Spain', spain: 'Spain', catalonia: 'Spain', aus: 'Australia', australia: 'Australia',
+  jp: 'Japan', japan: 'Japan', 'türkiye': 'Turkey', turkiye: 'Turkey', turkey: 'Turkey', czechia: 'Czech Republic',
+};
+
+export function getEventCountry(città: string): string {
+  const parts = (città || '').split(',');
+  if (parts.length > 1) {
+    const raw = parts[parts.length - 1].trim().toLowerCase();
+    if (COUNTRY_ALIAS[raw]) return COUNTRY_ALIAS[raw];
+    const titled = raw.replace(/\b\w/g, (ch) => ch.toUpperCase());
+    if (CONTINENTS[titled] || FLAGS[titled]) return titled;
+  }
+  const c = (città || '').toLowerCase();
   for (const [country, cities] of Object.entries(COUNTRY_CITIES)) {
     if (cities.some((name) => c.includes(name))) return country;
   }
   return 'Other';
 }
+
+export function getContinent(country: string): string {
+  return CONTINENTS[country] || 'Other';
+}
+
+export const CONTINENT_LIST = ['Europe', 'North America', 'South America', 'Asia', 'Oceania'];
 
 export function countryFlag(country: string): string {
   return FLAGS[country] || '🌍';


### PR DESCRIPTION
Rebuilds the home around the map and real filtering.

## What's new
- **Map is the hero** and **reactive**: it re-fits bounds when you filter, so it zooms to the selected region — Worldwide → whole world, **Europe → zooms Europe, Italy → zooms Italy**. Clicking a map pin filters the list by that city.
- **Location filter** above the shows: continent chips (Worldwide / Europe / N.America / S.America / Asia / Oceania) + **country chips with counts** — drives both map and list.
- **Upcoming-shows toolbar**: City search, **Period (from–to)**, **Genre** dropdown, and a **grid / list / compact** view toggle (compact = dense elenco rows). The three views are visually distinct.
- **Country counts fixed**: `getEventCountry` now parses the `City, Country` suffix (Italy et al. were undercounted) + continent mapping.
- **Removed the source (`fonte`) citation** from cards — we are the source.
- **Genre fix**: default subgenre `Progressive` → `Progressive Rock` (progressive alone isn't a genre); the 280 existing rows were renamed in the DB too.

Build passes (0 type errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)