### PR TITLE
fix(scraper): default subgenre → 'Progressive Rock'

### DIFF
--- a/scripts/scrape-events.mjs
+++ b/scripts/scrape-events.mjs
@@ -288,7 +288,7 @@ function classifySubgenre(eventName, description, artists) {
   for (const [subgenre, list] of Object.entries(keywords)) {
     if (list.some(matchesWord)) return subgenre;
   }
-  return 'Progressive';
+  return 'Progressive Rock';
 }
 
 // --- Supabase upsert (service role; same dedup key as upsert_evento) ---------


### PR DESCRIPTION
Keeps the scraper's classifySubgenre default in sync with the app and the renamed DB rows (progressive alone isn't a genre).

🤖 Generated with [Claude Code](https://claude.com/claude-code)